### PR TITLE
Implement sticky footer in RootLayout

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -24,9 +24,12 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        className={`${geistSans.variable} ${geistMono.variable} antialiased  flex flex-col min-h-screen`}>
         <Navbar />
+        <main className="flex-grow">
+
         {children}
+        </main>
         <Footer/>
       </body>
     </html>


### PR DESCRIPTION
- Modified RootLayout to use Flexbox for a sticky footer effect.
- Added flex properties to the body and main area to ensure the footer stays at the bottom regardless of content height.